### PR TITLE
Add separate constructor for 'server_address', check chunk size

### DIFF
--- a/src/ansys/utilities/filetransfer/_client.py
+++ b/src/ansys/utilities/filetransfer/_client.py
@@ -10,7 +10,7 @@ the Ansys filetransfer utility via gRPC.
 import hashlib
 import os
 import stat
-from typing import Generator, Optional, Union
+from typing import Generator, Optional
 
 import grpc
 


### PR DESCRIPTION
Change the default Client constructor to take an already-initialized
channel as an input.
To instantiate the Client with a server address, add a separate
constructor 'from_server_address'.

In the up- and download methods, check the chunk_size against the
configured max_message_length.

In the default constructor, the 'max_message_length' can be given
simply as a hint for this check; only 'from_server_address'
ensures that the channel is actually configured with the message
length.

Addresses the comments from #1.