### PR TITLE
Update project name where it was missed

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,7 +17,7 @@ cname = os.getenv("DOCUMENTATION_CNAME", "filetransfer.tools.docs.pyansys.com")
 html_logo = pyansys_logo_black
 html_theme = "ansys_sphinx_theme"
 
-html_title = html_short_title = "Filetransfer Utility Python Client"
+html_title = html_short_title = "Filetransfer Tool Python Client"
 
 # specify the location of your github repo
 html_theme_options = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-tools-filetransfer"
 version = "0.1.dev0"
-description = "A python client for the ansys filetransfer utility"
+description = "A Python client for the ansys filetransfer tool"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.maintainers@ansys.com>"]

--- a/src/ansys/tools/filetransfer/_client.py
+++ b/src/ansys/tools/filetransfer/_client.py
@@ -21,10 +21,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""A high-level Python Client for the Ansys Filetransfer utility.
+"""A high-level Python Client for the Ansys Filetransfer tool.
 
 This module implements a high-level Python client for interacting with
-the Ansys filetransfer utility via gRPC.
+the Ansys filetransfer tool via gRPC.
 """
 import hashlib
 import os
@@ -42,7 +42,7 @@ from ._log import LOGGER
 
 
 class Client:
-    """Ansys Filetransfer Utility high-level client module.
+    """Ansys Filetransfer Tool high-level client module.
 
     The filetransfer client provides a high-level API for uploading and
     downloading files to the filetransfer server.


### PR DESCRIPTION
Fix some instances where the rename from "filetransfer utility"
to "filtransfer tool" was missed.