### PR TITLE
Show the prev / next button

### DIFF
--- a/doc/changelog.d/132.documentation.md
+++ b/doc/changelog.d/132.documentation.md
@@ -1,0 +1,1 @@
+Show the prev / next button

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,7 +23,7 @@ html_title = html_short_title = "Filetransfer Tool Python Client"
 html_theme_options = {
     "logo": "pyansys",
     "github_url": "https://github.com/ansys/ansys-tools-filetransfer",
-    "show_prev_next": False,
+    "show_prev_next": True,
     "show_breadcrumbs": True,
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),


### PR DESCRIPTION
Show the prev / next button at the bottom of documentation pages.